### PR TITLE
Removed alert-dismissible and added note for the dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If someone know, please email me or create an issue. I would love to credit the 
 ```html
 <script src="cookiealert-standalone.js"></script>
 ```
-> **Note:**  
-> Use the dependency version only if you already included jQuery and jsCookie.
-
 ### Take a look at [`demo.html`](https://github.com/Wruczek/Bootstrap-Cookie-Alert/blob/gh-pages/demo.html) for a working example
+
+**Note:**  
+Both `standalone` and `dependency` versions accomplish the same. The `dependency` version is a little bit smaller and cleaner, but requires `jQuery` and `jsCookie`. Use it only if you already have those libraries included on your site. If not, it is strongly recommended to omit loading additional libraries and go with the `standalone` version.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If someone know, please email me or create an issue. I would love to credit the 
 #### 2. Add the html markup:
 ```html
 <!-- COOKIES -->
-<div class="alert alert-dismissible text-center cookiealert" role="alert">
+<div class="alert text-center cookiealert" role="alert">
     <div class="cookiealert-container">
         <b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="http://cookiesandyou.com/" target="_blank">Learn more</a>
 
@@ -32,5 +32,7 @@ If someone know, please email me or create an issue. I would love to credit the 
 ```html
 <script src="cookiealert-standalone.js"></script>
 ```
+> **Note:**  
+> Use the dependency version only if you already included jQuery and jsCookie.
 
 ### Take a look at [`demo.html`](https://github.com/Wruczek/Bootstrap-Cookie-Alert/blob/gh-pages/demo.html) for a working example

--- a/demo.html
+++ b/demo.html
@@ -26,7 +26,7 @@
 </div>
 
 <!-- COOKIES -->
-<div class="alert alert-dismissible text-center cookiealert" role="alert">
+<div class="alert text-center cookiealert" role="alert">
     <div class="cookiealert-container">
         <b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="http://cookiesandyou.com/" target="_blank">Learn more</a>
 


### PR DESCRIPTION
I removed the `alert-dismissible` class from the alert, due to the fact that it simply adds a padding to the right side which causes the content to be asymmetrically.

As mentioned in #2 , I added a note for the dependency version in the readme.

Regards
Andi