### PR TITLE
A couple of accessibility-related improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I try to keep it up-to-date. Let me know if I forget to release an update.
 <div class="alert text-center cookiealert" role="alert">
     <b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="https://cookiesandyou.com/" target="_blank">Learn more</a>
 
-    <button type="button" class="btn btn-primary btn-sm acceptcookies" aria-label="Close">
+    <button type="button" class="btn btn-primary btn-sm acceptcookies">
         I agree
     </button>
 </div>

--- a/cookiealert.css
+++ b/cookiealert.css
@@ -11,6 +11,7 @@
     margin: 0 !important;
     z-index: 999;
     opacity: 0;
+    visibility: hidden;
     border-radius: 0;
     transform: translateY(100%);
     transition: all 500ms ease-out;
@@ -20,6 +21,7 @@
 
 .cookiealert.show {
     opacity: 1;
+    visibility: visible;
     transform: translateY(0%);
     transition-delay: 1000ms;
 }

--- a/demo.html
+++ b/demo.html
@@ -29,7 +29,7 @@
 <div class="alert text-center cookiealert" role="alert">
     <b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="https://cookiesandyou.com/" target="_blank">Learn more</a>
 
-    <button type="button" class="btn btn-primary btn-sm acceptcookies" aria-label="Close">
+    <button type="button" class="btn btn-primary btn-sm acceptcookies">
         I agree
     </button>
 </div>


### PR DESCRIPTION
My colleague noted that since this cookie markup is always present in the DOM, but just visually hidden via `opacity: 0` and `transform: translateY`, folks who may be unable to use a mouse and instead rely on keyboards alone (or other assistive technology) would always have to tab past any buttons or links in this markup, even after they've accepted the cookie. 

Changing the CSS to `display: none` or `visibility: hidden` should prevent its contents from being focusable, but `display: none` doesn't mesh well with CSS transitions, so my commit uses `visbility: hidden` instead, which at least in my testing seems to wait till the end of the post-`.show`-removal transition to take effect.

I was also listening to this content in some screen readers (JAWS and NVDA) to confirm that `visibility: hidden` removes the text content from the accessibility tree (wouldn't want low-vision users having to hear that content on every page load), but was surprised to hear "Close" instead of "I agree" when tabbing to that button. Since I didn't see a reason that said button text should, by default, be different for blind/low-vision users (and in our case, the lawyers were very intentional in the specific button language they wanted), I also made a commit to remove the `aria-label`.