### PR TITLE
Add compatibility with Webpack Encore

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "bootstrap-4",
     "cookie-alert"
   ],
+  "style": "cookiealert.css",
+  "module": "cookiealert.js",
   "author": "Wruczek <wruczekk@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
In order to reference this file in the main app.js of Webpack Encore, we needed to add the reference to the js and css file or the build would fail.

Fixes #16 