### PR TITLE
Add deny button

### DIFF
--- a/cookiealert.css
+++ b/cookiealert.css
@@ -30,7 +30,7 @@
     text-decoration: underline
 }
 
-.cookiealert .acceptcookies {
+.cookiealert .acceptcookies,.denycookies {
     margin-left: 10px;
     vertical-align: baseline;
 }

--- a/cookiealert.js
+++ b/cookiealert.js
@@ -7,7 +7,8 @@
     "use strict";
 
     var cookieAlert = document.querySelector(".cookiealert");
-    var acceptCookies = document.querySelector(".acceptcookies");
+	var acceptCookies = document.querySelector(".acceptcookies");
+	var denyCookies = document.querySelector(".denycookies");
 
     if (!cookieAlert) {
        return;
@@ -16,7 +17,7 @@
     cookieAlert.offsetHeight; // Force browser to trigger reflow (https://stackoverflow.com/a/39451131)
 
     // Show the alert if we cant find the "acceptCookies" cookie
-    if (!getCookie("acceptCookies")) {
+    if (getCookie("acceptCookies") == "") {
         cookieAlert.classList.add("show");
     }
 
@@ -28,7 +29,19 @@
 
         // dispatch the accept event
         window.dispatchEvent(new Event("cookieAlertAccept"))
-    });
+	});
+	
+	// When clicking on the deny button, create a 1 year
+	// cookie to remember user's choice and close the banner
+	if(denyCookies != undefined){
+		denyCookies.addEventListener("click", function () {
+			setCookie("acceptCookies", false, 365);
+			cookieAlert.classList.remove("show");
+	
+			// dispatch the accept event
+			window.dispatchEvent(new Event("cookieAlertDeny"))
+		});
+	}
 
     // Cookie functions from w3schools
     function setCookie(cname, cvalue, exdays) {

--- a/demo.html
+++ b/demo.html
@@ -29,6 +29,9 @@
 <div class="alert text-center cookiealert" role="alert">
     <b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="https://cookiesandyou.com/" target="_blank">Learn more</a>
 
+	<button type="button" class="btn btn-primary btn-sm denycookies">
+        Deny
+    </button>
     <button type="button" class="btn btn-primary btn-sm acceptcookies">
         I agree
     </button>


### PR DESCRIPTION
Should be backwards compatible.

Adds a button for denying cookies, which sets the acceptCookies cookie to false instead of true.

If acceptCookies is undefined, the alert will show as usual. If it's either true or false, it won't.

Also implements an event that fires when the deny button is clicked.

Partially fixes https://github.com/Wruczek/Bootstrap-Cookie-Alert/issues/19